### PR TITLE
fix(test_scripts): improve ANSI escape color sequence compatibility for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LiteRT CLI (Fishfood)
+# LiteRT CLI (Preview)
 
 A convenient command-line toolkit to streamline LiteRT development workflow,
 including converting, quantizing, compiling, managing, running, and benchmarking

--- a/test_scripts/litert_cli_test_commands.sh
+++ b/test_scripts/litert_cli_test_commands.sh
@@ -23,6 +23,17 @@ TOTAL_PASSED=0
 TOTAL_FAILED=0
 FAILED_CASES=()
 
+# Define ANSI color codes using \033 for maximum compatibility across Linux and macOS
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+WHITE='\033[1;37m'
+GRAY='\033[90m'
+BOLD='\033[1m'
+BOLD_RED='\033[1;31m'
+BOLD_GREEN='\033[1;32m'
+NC='\033[0m' # No Color
+
 # Helper for dynamic Android check
 function has_android_device() {
   adb devices | grep -q "[0-9a-zA-Z]\+.*device$"
@@ -30,7 +41,7 @@ function has_android_device() {
 
 function log_section() {
   echo -e "\n=================================================================="
-  echo -e ">>> \e[1m$1\e[0m"
+  echo -e ">>> ${BOLD}$1${NC}"
   echo -e "=================================================================="
 }
 
@@ -39,9 +50,9 @@ function run_case() {
     local title="$1"
     shift
     
-    echo -e "\n\e[34m▶ Running:\e[0m \e[1;37m$title\e[0m"
-    echo -e "\e[90mCommand: $*\e[0m"
-    echo -e "\e[90m------------------------------------------------------------\e[0m"
+    echo -e "\n${BLUE}▶ Running:${NC} ${WHITE}$title${NC}"
+    echo -e "${GRAY}Command: $*${NC}"
+    echo -e "${GRAY}------------------------------------------------------------${NC}"
     
     # Execute the command (disabling immediate exit on failure just for the test command)
     set +e
@@ -49,12 +60,12 @@ function run_case() {
     local status=$?
     set -e
     
-    echo -e "\e[90m------------------------------------------------------------\e[0m"
+    echo -e "${GRAY}------------------------------------------------------------${NC}"
     if [ $status -eq 0 ]; then
-        echo -e "\e[32m✔ SUCCESS:\e[0m \e[1;32m$title\e[0m"
+        echo -e "${GREEN}✔ SUCCESS:${NC} ${BOLD_GREEN}$title${NC}"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
     else
-        echo -e "\e[31m✘ FAILED (Exit Code: $status):\e[0m \e[1;31m$title\e[0m"
+        echo -e "${RED}✘ FAILED (Exit Code: $status):${NC} ${BOLD_RED}$title${NC}"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
         FAILED_CASES+=("$title")
     fi
@@ -64,21 +75,21 @@ function run_case() {
 
 function print_test_summary() {
     echo -e "\n=================================================================="
-    echo -e ">>> \e[1mTEST SUMMARY\e[0m"
+    echo -e ">>> ${BOLD}TEST SUMMARY${NC}"
     echo -e "=================================================================="
-    echo -e "Total Test Cases Run: \e[1m$TOTAL_CASES\e[0m"
-    echo -e "Passed:              \e[1;32m$TOTAL_PASSED\e[0m"
-    echo -e "Failed:              \e[1;31m$TOTAL_FAILED\e[0m"
+    echo -e "Total Test Cases Run: ${BOLD}$TOTAL_CASES${NC}"
+    echo -e "Passed:              ${BOLD_GREEN}$TOTAL_PASSED${NC}"
+    echo -e "Failed:              ${BOLD_RED}$TOTAL_FAILED${NC}"
     
     if [ $TOTAL_FAILED -gt 0 ]; then
-        echo -e "\n\e[1;31mFailed Test Cases:\e[0m"
+        echo -e "\n${BOLD_RED}Failed Test Cases:${NC}"
         for case in "${FAILED_CASES[@]}"; do
-            echo -e "  - \e[1;31m$case\e[0m"
+            echo -e "  - ${BOLD_RED}$case${NC}"
         done
         echo -e "=================================================================="
         return 1
     fi
-    echo -e "\e[1;32mAll tests completed successfully!\e[0m"
+    echo -e "${BOLD_GREEN}All tests completed successfully!${NC}"
     echo -e "=================================================================="
     return 0
 }

--- a/test_scripts/run_cli_demo.sh
+++ b/test_scripts/run_cli_demo.sh
@@ -20,6 +20,11 @@ set -e
 export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# Define ANSI color codes using \033 for maximum compatibility across Linux and macOS
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
 # Create Python virtual environment if not exists
 if [ ! -d "venv" ]; then
   echo "Creating virtual environment..."
@@ -48,9 +53,9 @@ function download_if_not_exists() {
   local main_ref=${ref%%:*}
 
   if [ -d "$MODELS_CACHE/$main_ref" ]; then
-    echo -e "\033[32m>>> Model reference '$main_ref' already exists in cache, skipping download.\033[0m"
+    echo -e "${GREEN}>>> Model reference '$main_ref' already exists in cache, skipping download.${NC}"
   else
-    echo -e "\033[33m>>> Downloading model '$ref'...\033[0m"
+    echo -e "${YELLOW}>>> Downloading model '$ref'...${NC}"
     if [ -n "$file_pattern" ]; then
       litert download "$repo" --file "$file_pattern" --model-ref "$ref"
     else
@@ -78,4 +83,4 @@ fi
 echo "Running mobilenetv3 on GCP..."
 litert benchmark mobilenetv3 --gcp --devices "pixel 8, sm-s931u1" --gpu
 
-echo -e "\n\033[32mDemo completed successfully!\033[0m"
+echo -e "\n${GREEN}Demo completed successfully!${NC}"


### PR DESCRIPTION
This PR improves the compatibility of ANSI escape sequences in test and demo scripts on macOS by defining color variables with standard octal `\033` codes. It also changes raw escapes to descriptive variables in both `litert_cli_test_commands.sh` and `run_cli_demo.sh`.