### PR TITLE
Update version to 0.1.1.dev24 and skip NPU compilation on non-Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ source .venv/bin/activate
 pip install -e .
 
 # Install from Test PyPI
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple litert-cli==0.1.1.dev23
+pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple litert-cli==0.1.1.dev24
 ```
 
 ### Tested Platforms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "litert-cli"
-version = "0.1.1.dev23"
+version = "0.1.1.dev24"
 
 description = "LiteRT Toolkit Command Line Interface"
 dependencies = [

--- a/test_scripts/run_cli_npu.sh
+++ b/test_scripts/run_cli_npu.sh
@@ -83,6 +83,12 @@ run_case "Benchmark Original Model on NPU" \
     litert benchmark "$EFFICIENTNET_TFLITE" --android --npu
 
 # --- 4. Compile for Detected Target ---
+if [[ "$(uname)" != "Linux" ]]; then
+    echo -e "\n${YELLOW}Skipping compilation and dependent tests on non-Linux platform ($(uname))${NC}"
+    print_summary_report "NPU Tests"
+    exit 0
+fi
+
 mkdir -p "$MODEL_DIR/compiled"
 
 run_case "Compile for Detected Target ($TARGET_SOC)" \


### PR DESCRIPTION
This PR updates the version to 0.1.1.dev24 in README.md and pyproject.toml, and adds a platform check to skip NPU compilation and dependent tests on non-Linux platforms in test_scripts/run_cli_npu.sh.