### PR TITLE
Implement desktop benchmarking execution engine and update documentation to install litert-cli-nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ source .venv/bin/activate
 
 #### 2. Install `litert-cli`
 
-##### 2a. Install from Test PyPI
+##### 2a. Install from PyPI
 
 ```bash
 # Install the package into the active virtual environment
-uv pip install -q -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple litert-cli==0.1.1.dev24
+uv pip install -q litert-cli-nightly
 ```
 
 ##### 2b. Or Install from Local Clone (Recommended for Development)
@@ -91,10 +91,10 @@ source .venv/bin/activate
 
 #### 2. Install `litert-cli`
 
-##### 2a. Install from Test PyPI
+##### 2a. Install from PyPI
 
 ```bash
-pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple litert-cli==0.1.1.dev24
+pip install -q litert-cli-nightly
 ```
 
 ##### 2b. Or Install from Local Clone
@@ -249,6 +249,16 @@ litert benchmark model.tflite --android --gpu
 
 # Benchmark on macOS (CPU)
 litert benchmark my_model_ref --desktop --cpu
+
+# Benchmark on Google AI Edge Portal in Google Cloud. Prerequisites:
+# - Set up your Google AI Edge Portal account by following up the instructions at:
+#   https://ai.google.dev/edge/ai-edge-portal
+# - Set up authentication by running: gcloud auth login
+# - You can set the default GCP project by setting the environment variable LITERT_GCP_PROJECT, or by providing the --gcp-project option.
+# - You can specific your GCP bucket by --gcp-bucket, otherwise, it will create default
+#   one.
+litert benchmark model.tflite --gcp --device "pixel 7" --gcp-project "your-gcp-project-id" --gcp-bucket "your-gcp-bucket"
+litert benchmark model.tflite --gcp --devices "pixel 7, sm-s931u1" --gpu
 ```
 
 ### 7. Visualize a model's architecture

--- a/test_scripts/litert_cli.ipynb
+++ b/test_scripts/litert_cli.ipynb
@@ -3,8 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "view-in-github",
-    "colab_type": "text"
+    "colab_type": "text",
+    "id": "view-in-github"
    },
    "source": [
     "<a href=\"https://colab.research.google.com/github/google-ai-edge/LiteRT-CLI/blob/main/test_scripts/litert_cli.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -73,7 +73,7 @@
     "!pip install torch torchvision\n",
     "\n",
     "# Install litert-cli\n",
-    "!pip install -q -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple litert-cli==0.1.1.dev24\n",
+    "!pip install litert-cli-nightly\n",
     "\n",
     "# 'litert compile' depends on Clang, and below make sure your Clang has version `18.x.x` or above\n",
     "!wget https://apt.llvm.org/llvm.sh\n",


### PR DESCRIPTION
   - Updates `README.md` and `test_scripts/litert_cli.ipynb` to install `litert-cli-nightly` directly from official PyPI, replacing legacy Test PyPI development wheel pins (`0.1.1.dev24`).