### PR TITLE
Update Colab notebook: use litert-cli-nightly, add torchao, and update GCP benchmark instructions

### DIFF
--- a/test_scripts/litert_cli.ipynb
+++ b/test_scripts/litert_cli.ipynb
@@ -3,8 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "view-in-github",
-    "colab_type": "text"
+    "colab_type": "text",
+    "id": "view-in-github"
    },
    "source": [
     "<a href=\"https://colab.research.google.com/github/google-ai-edge/LiteRT-CLI/blob/main/test_scripts/litert_cli.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -71,9 +71,11 @@
     "!pip install -U protobuf\n",
     "# Install required packages\n",
     "!pip install torch torchvision\n",
+    "# Default torchao is \n",
+    "!pip install -U torchao\n",
     "\n",
     "# Install litert-cli\n",
-    "!pip install -q -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple litert-cli==0.1.1.dev24\n",
+    "!pip install litert-cli-nightly\n",
     "\n",
     "# 'litert compile' depends on Clang, and below make sure your Clang has version `18.x.x` or above\n",
     "!wget https://apt.llvm.org/llvm.sh\n",
@@ -241,9 +243,9 @@
     "# Benchmark on Google AI Edge Portal\n",
     "# Please specify you own GCP project: --gcp-project <your-own-gcp-project-id>\n",
     "# Or set a default environment variable: LITERT_GCP_PROJECT\n",
-    "!litert benchmark model.tflite --gcp --device \"pixel 7\" --cpu --gcp-project aep-e2e-test\n",
-    "!litert benchmark model.tflite --gcp --device \"pixel 7\" --gpu --gcp-project aep-e2e-test\n",
-    "!litert benchmark model.tflite --gcp --devices \"pixel 7, sm-s931u1\" --gpu"
+    "# Optionally specify your GCS bucket via --gcp-bucket, otherwise it will automatically create and use one.\n",
+    "!litert benchmark resnet18/resnet18.tflite --gcp --device \"pixel 7\" --cpu --gcp-project <your-gcp-project>\n",
+    "!litert benchmark resnet18/resnet18.tflite --gcp --devices \"pixel 7, sm-s931u1\" --gpu --gcp-project <your-gcp-project> --gcp-bucket <your-gcp-bucket>"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the Colab demo notebook to:
- Install `litert-cli-nightly` instead of a pinned dev build from test.pypi.
- Install `torchao`.
- Update GCP benchmark instructions and examples to use `resnet18/resnet18.tflite` and prompt for GCP project/bucket parameters.