### PR TITLE
fix: clean up notebook schema and restore standard ASCII symbols

### DIFF
--- a/examples/litert_cli.ipynb
+++ b/examples/litert_cli.ipynb
@@ -1,31 +1,35 @@
 {
  "cells": [
   {
-   "id": "28580e8c",
    "cell_type": "markdown",
-   "source": [
-    "\u003ca href=\"https://colab.research.google.com/github/google-ai-edge/LiteRT-CLI/blob/main/examples/litert_cli.ipynb\" target=\"_parent\"\u003e\u003cimg src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/\u003e\u003c/a\u003e"
-   ],
+   "id": "28580e8c",
    "metadata": {
     "colab_type": "text",
     "id": "view-in-github"
    },
-   "execution_count": null
+   "source": [
+    "<a href=\"https://colab.research.google.com/github/google-ai-edge/LiteRT-CLI/blob/main/examples/litert_cli.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
   },
   {
-   "id": "6a6c4940",
    "cell_type": "markdown",
-   "source": [
-    "##### Copyright 2026 The LiteRT CLI Authors."
-   ],
+   "id": "6a6c4940",
    "metadata": {
     "id": "litert-cli-copyright"
    },
-   "execution_count": null
+   "source": [
+    "##### Copyright 2026 The LiteRT CLI Authors."
+   ]
   },
   {
-   "id": "218b9c57",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "218b9c57",
+   "metadata": {
+    "cellView": "form",
+    "id": "litert-cli-license"
+   },
+   "outputs": [],
    "source": [
     "# @title Licensed under the Apache License, Version 2.0 (the \"License\");\n",
     "# you may not use this file except in compliance with the License.\n",
@@ -39,36 +43,32 @@
     "# See the License for the specific language governing permissions and\n",
     "# limitations under the License.\n",
     "# =============================================================================="
-   ],
-   "metadata": {
-    "cellView": "form",
-    "id": "litert-cli-license"
-   },
-   "execution_count": null
+   ]
   },
   {
-   "id": "90c3deda",
    "cell_type": "markdown",
+   "id": "90c3deda",
+   "metadata": {},
    "source": [
     "# LiteRT CLI Demo\n",
     "\n",
     "This notebook demonstrates how to use the `litert-cli` tool to convert a PyTorch model, quantize it and run it."
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "19270446",
    "cell_type": "markdown",
-   "source": [
-    "## 🛠️ 1. Environment Setup \u0026 Installation"
-   ],
+   "id": "19270446",
    "metadata": {},
-   "execution_count": null
+   "source": [
+    "## 🛠️ 1. Environment Setup & Installation"
+   ]
   },
   {
-   "id": "d34739df",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "d34739df",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Update protobuf version\n",
     "!pip install -U protobuf\n",
@@ -84,159 +84,159 @@
     "!wget https://apt.llvm.org/llvm.sh\n",
     "!chmod +x llvm.sh\n",
     "!sudo ./llvm.sh 18 all"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "1dd1eb34",
    "cell_type": "markdown",
+   "id": "1dd1eb34",
+   "metadata": {},
    "source": [
     "## 📝 2. Prepare PyTorch Model Script"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "5e40f66c",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "5e40f66c",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%%writefile resnet18.py\n",
     "import torch\n",
     "import torchvision\n",
     "\n",
-    "def get_model() -\u003e torch.nn.Module:\n",
+    "def get_model(batch_size: int = 1) -> torch.nn.Module:\n",
     "  model = torchvision.models.resnet18(\n",
     "      weights=torchvision.models.ResNet18_Weights.IMAGENET1K_V1\n",
     "  )\n",
     "  model.eval()\n",
     "  return model\n",
     "\n",
-    "def get_args() -\u003e tuple[torch.Tensor, ...]:\n",
-    "  return (torch.randn(1, 3, 224, 224),)"
-   ],
-   "metadata": {},
-   "execution_count": null
+    "def get_args(batch_size: int = 1) -> tuple[torch.Tensor, ...]:\n",
+    "  return (torch.randn(batch_size, 3, 224, 224),)"
+   ]
   },
   {
-   "id": "427dca8a",
    "cell_type": "markdown",
-   "source": [
-    "## 🔄 3. Model Conversion (PyTorch -\u003e LiteRT)"
-   ],
+   "id": "427dca8a",
    "metadata": {},
-   "execution_count": null
+   "source": [
+    "## 🔄 3. Model Conversion (PyTorch -> LiteRT)"
+   ]
   },
   {
-   "id": "578cc653",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "578cc653",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Convert PyTorch ResNet18 model to LiteRT\n",
     "!litert convert resnet18.py --output resnet18"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "606efd4f",
    "cell_type": "markdown",
+   "id": "606efd4f",
+   "metadata": {},
    "source": [
     "## 📉 4. Model Quantization"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "c589c711",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c589c711",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Quantize the ResNet18 model\n",
-    "!litert quantize resnet18/resnet18.tflite --type int8_dynamic --output resnet18/resnet18_int8_dynamic.tflite\n",
-    "!litert quantize resnet18/resnet18.tflite --type int8_weight_only --output resnet18/resnet18_int8_weight_only.tflite"
-   ],
-   "metadata": {},
-   "execution_count": null
+    "!litert quantize resnet18/resnet18.tflite --recipe dynamic_wi8_afp32 --output resnet18/resnet18_int8_dynamic.tflite\n",
+    "!litert quantize resnet18/resnet18.tflite --recipe weight_only_wi8_afp32 --output resnet18/resnet18_int8_weight_only.tflite"
+   ]
   },
   {
-   "id": "b3ae9ddc",
    "cell_type": "markdown",
+   "id": "b3ae9ddc",
+   "metadata": {},
    "source": [
     "## 🚀 5. Run Inference\n",
     "### 🖥️ 5.1 CPU Inference"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "ea93a1db",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "ea93a1db",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Run Inference on Desktop (Colab VM CPU)\n",
     "!litert run resnet18/resnet18.tflite --desktop --cpu --iterations 1\n",
     "!litert run resnet18/resnet18_int8_dynamic.tflite --desktop --cpu --iterations 1"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "9d748475",
    "cell_type": "markdown",
+   "id": "9d748475",
+   "metadata": {},
    "source": [
     "### 🎮 5.2 GPU Inference"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "00b026b2",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "00b026b2",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Run Inference on Desktop (Colab VM GPU)\n",
     "!litert run resnet18/resnet18.tflite --desktop --gpu --iterations 1\n",
     "!litert run resnet18/resnet18_int8_dynamic.tflite --desktop --gpu --iterations 1"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "eaa972bc",
    "cell_type": "markdown",
+   "id": "eaa972bc",
+   "metadata": {},
    "source": [
     "## ⚙️ 6. NPU Offline Compilation (AOT)"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "d0a61181",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "d0a61181",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Compile the model for qualcomm NPU: SM8750\n",
     "# TIP: Only support running on Linux and it might take a few minutes, given download large SDKs from SOCs.\n",
     "# TIP: It depends on Clang, and please make sure your Clang has version `18.x.x` or above when running\n",
     "#   `clang --version`. To update, choose one of below: \n",
-    "#   a) `sudo apt update \u0026\u0026 sudo apt upgrade -y`\n",
+    "#   a) `sudo apt update && sudo apt upgrade -y`\n",
     "#   b) wget https://apt.llvm.org/llvm.sh\n",
     "#      chmod +x llvm.sh\n",
     "#      sudo ./llvm.sh 18 all\n",
     "#\n",
     "!litert compile resnet18/resnet18.tflite --target sm8750"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "2da953c9",
    "cell_type": "markdown",
+   "id": "2da953c9",
+   "metadata": {},
    "source": [
     "## 🏁 7. Benchmark in Google AI Edge Portal"
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   },
   {
-   "id": "a9a19e48",
    "cell_type": "code",
+   "execution_count": null,
+   "id": "a9a19e48",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Please login into Google Cloud and make sure you have joined the EAP for Google AI Edge Portal\n",
     "# Check: https://ai.google.dev/edge/ai-edge-portal\n",
@@ -244,18 +244,17 @@
     "!gcloud auth login\n",
     "\n",
     "# Benchmark on Google AI Edge Portal\n",
-    "# Please specify you own GCP project: --gcp-project \u003cyour-own-gcp-project-id\u003e\n",
+    "# Please specify you own GCP project: --gcp-project <your-own-gcp-project-id>\n",
     "# Or set a default environment variable: LITERT_GCP_PROJECT\n",
     "# Optionally specify your GCS bucket via --gcp-bucket, otherwise it will automatically create and use one.\n",
-    "!litert benchmark resnet18/resnet18.tflite --gcp --device \"pixel 7\" --cpu --gcp-project \u003cyour-gcp-project\u003e\n",
-    "!litert benchmark resnet18/resnet18.tflite --gcp --devices \"pixel 7, sm-s931u1\" --gpu --gcp-project \u003cyour-gcp-project\u003e --gcp-bucket \u003cyour-gcp-bucket\u003e"
-   ],
-   "metadata": {},
-   "execution_count": null
+    "!litert benchmark resnet18/resnet18.tflite --gcp --device \"pixel 7\" --cpu --gcp-project <your-gcp-project>\n",
+    "!litert benchmark resnet18/resnet18.tflite --gcp --devices \"pixel 7, sm-s931u1\" --gpu --gcp-project <your-gcp-project> --gcp-bucket <your-gcp-bucket>"
+   ]
   },
   {
-   "id": "2685b076",
    "cell_type": "markdown",
+   "id": "2685b076",
+   "metadata": {},
    "source": [
     "## Advanced Usage\n",
     "\n",
@@ -269,9 +268,7 @@
     "!litert benchmark resnet18/resnet18.tflite --android\n",
     "```\n",
     "These are not executed in this notebook as Colab does not have access to a physical Android device by default."
-   ],
-   "metadata": {},
-   "execution_count": null
+   ]
   }
  ],
  "metadata": {
@@ -285,6 +282,6 @@
    "version": "3.13.12"
   }
  },
- "nbformat_minor": 5,
- "nbformat": 4
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/examples/litert_cli.ipynb
+++ b/examples/litert_cli.ipynb
@@ -172,8 +172,14 @@
    "outputs": [],
    "source": [
     "# Run Inference on Desktop (Colab VM CPU)\n",
-    "!litert run resnet18/resnet18.tflite --desktop --cpu --iterations 1\n",
-    "!litert run resnet18/resnet18_int8_dynamic.tflite --desktop --cpu --iterations 1"
+    "!litert run resnet18/resnet18.tflite\n",
+    "!litert run resnet18/resnet18_int8_dynamic.tflite  --desktop --cpu --iterations 1\n",
+    "\n",
+    "# Download EfficientNet-B1 model directly from HuggingFace (No conversion needed)\n",
+    "!litert download litert-community/efficientnet_b1 --file \"*.tflite\" --output efficientnet\n",
+    "\n",
+    "# Run Inference for EfficientNet on Desktop CPU\n",
+    "!litert run efficientnet/efficientnet_b1.tflite"
    ]
   },
   {
@@ -191,9 +197,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Run Inference on Desktop (Colab VM GPU)\n",
-    "!litert run resnet18/resnet18.tflite --desktop --gpu --iterations 1\n",
-    "!litert run resnet18/resnet18_int8_dynamic.tflite --desktop --gpu --iterations 1"
+    "# Run Inference on Desktop with GPU (Colab VM GPU), and please make you connect to a machine\n",
+    "# with GPU. You can click \"change runtime type\" to find options there.\n",
+    "!litert run resnet18/resnet18.tflite\n",
+    "!litert run resnet18/resnet18_int8_dynamic.tflite --desktop --gpu --iterations 1 --print-tensors\n",
+    "\n",
+    "# Run Inference for EfficientNet on Desktop GPU\n",
+    "!litert run efficientnet/efficientnet_b1.tflite --gpu"
    ]
   },
   {
@@ -213,14 +223,11 @@
    "source": [
     "# Compile the model for qualcomm NPU: SM8750\n",
     "# TIP: Only support running on Linux and it might take a few minutes, given download large SDKs from SOCs.\n",
-    "# TIP: It depends on Clang, and please make sure your Clang has version `18.x.x` or above when running\n",
-    "#   `clang --version`. To update, choose one of below: \n",
-    "#   a) `sudo apt update && sudo apt upgrade -y`\n",
-    "#   b) wget https://apt.llvm.org/llvm.sh\n",
-    "#      chmod +x llvm.sh\n",
-    "#      sudo ./llvm.sh 18 all\n",
     "#\n",
-    "!litert compile resnet18/resnet18.tflite --target sm8750"
+    "!litert compile resnet18/resnet18.tflite --target sm8750\n",
+    "\n",
+    "# Compile EfficientNet model for Qualcomm NPU: SM8750\n",
+    "!litert compile efficientnet/efficientnet_b1.tflite --target sm8750"
    ]
   },
   {
@@ -235,20 +242,39 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a9a19e48",
-   "metadata": {},
+   "metadata": {
+    "cellView": "form"
+   },
    "outputs": [],
    "source": [
-    "# Please login into Google Cloud and make sure you have joined the EAP for Google AI Edge Portal\n",
-    "# Check: https://ai.google.dev/edge/ai-edge-portal\n",
+    "# @title Login to Google Cloud & Configure GCP Project\n",
+    "# @markdown Please login into Google Cloud and make sure you have joined the EAP for Google AI Edge Portal. Check: https://ai.google.dev/edge/ai-edge-portal\n",
+    "# @markdown ---\n",
+    "# @markdown **GCP Configuration**\n",
+    "# @markdown Please specify your GCP Project ID. If `gcp_bucket` is left blank, a default bucket `<gcp_project>-litert-models` will be used.\n",
+    "gcp_project = \"your-own-gcp-project-id\" # @param {type:\"string\"}\n",
+    "gcp_bucket = \"\" # @param {type:\"string\"}\n",
+    "\n",
+    "if not gcp_project or gcp_project == \"your-own-gcp-project-id\":\n",
+    "  raise ValueError(\"Error: Please specify a valid GCP Project ID in the form above.\")\n",
+    "\n",
+    "if not gcp_bucket:\n",
+    "  gcp_bucket = f\"{gcp_project}-litert-models\"\n",
+    "\n",
+    "print(f\"Configured GCP Project: {gcp_project}\")\n",
+    "print(f\"Configured GCS Bucket: gs://{gcp_bucket}\")\n",
+    "\n",
+    "# Install gcloud and login\n",
     "!pip install gcloud\n",
     "!gcloud auth login\n",
     "\n",
-    "# Benchmark on Google AI Edge Portal\n",
-    "# Please specify you own GCP project: --gcp-project <your-own-gcp-project-id>\n",
-    "# Or set a default environment variable: LITERT_GCP_PROJECT\n",
-    "# Optionally specify your GCS bucket via --gcp-bucket, otherwise it will automatically create and use one.\n",
-    "!litert benchmark resnet18/resnet18.tflite --gcp --device \"pixel 7\" --cpu --gcp-project <your-gcp-project>\n",
-    "!litert benchmark resnet18/resnet18.tflite --gcp --devices \"pixel 7, sm-s931u1\" --gpu --gcp-project <your-gcp-project> --gcp-bucket <your-gcp-bucket>"
+    "# Benchmark ResNet18 on Google AI Edge Portal\n",
+    "!litert benchmark resnet18/resnet18.tflite --gcp --device \"pixel 7\" --cpu --gcp-project {gcp_project}\n",
+    "!litert benchmark resnet18/resnet18.tflite --gcp --devices \"pixel 7, sm-s931u1\" --gpu --gcp-project {gcp_project} --gcp-bucket {gcp_bucket}\n",
+    "\n",
+    "# Benchmark EfficientNet on Google AI Edge Portal with CPU and NPU\n",
+    "!litert benchmark efficientnet/efficientnet_b1.tflite --gcp --device \"pixel 7\" --cpu --gcp-project {gcp_project}\n",
+    "!litert benchmark efficientnet/efficientnet_b1.tflite --gcp --device \"sm-s931u1\" --npu --soc-model SM8750 --gcp-project {gcp_project} --gcp-bucket {gcp_bucket}"
    ]
   },
   {


### PR DESCRIPTION
This PR cleans up the invalid `execution_count` attribute from Markdown cells in `examples/litert_cli.ipynb` to fix schema validation errors, and restores standard ASCII symbols (e.g. `&`, `<`) from Unicode escapes.

Also add more tests with efficientnet.