### PR TITLE
feat(smollm2): expand SmolLM2 demo script with advanced commands.

### DIFF
--- a/examples/models/presets/default.py
+++ b/examples/models/presets/default.py
@@ -1,0 +1,2 @@
+# System Preset for SmolLM2
+system_instruction = "You are a concise AI assistant. Answer in two sentences or less."

--- a/examples/models/smollm2.sh
+++ b/examples/models/smollm2.sh
@@ -23,17 +23,72 @@ source "$(dirname "${BASH_SOURCE[0]}")/../utils.sh"
 
 setup_test_env "smollm2" "SmolLM2 LLM Demo Script"
 
-# --- 1. Convert HuggingFace Model HuggingFaceTB/SmolLM2-360M-Instruct ---
-run_case "Convert: HuggingFace HuggingFaceTB/SmolLM2-360M-Instruct" \
-    litert convert HuggingFaceTB/SmolLM2-360M-Instruct --output "models/smollm2"
+# --- Variables ---
+MODEL_DIR="models/smollm2"
+MODEL_INT4_DIR="models/smollm2_int4"
+MODEL_PATH="${MODEL_DIR}/model.litertlm"
+MODEL_INT4_PATH="${MODEL_INT4_DIR}/model.litertlm"
+PRESET_PATH="${REPO_ROOT}/examples/models/presets/default.py"
 
-# --- 2. Run SmolLM2 Generative LLM Model ---
-run_case "Run SmolLM2: Generative inference with custom prompt" \
-    litert lm run models/smollm2/model.litertlm --prompt="What is the capital of France?"
+# --- 1. Convert HuggingFace Model ---
+run_case "Convert: HuggingFace SmolLM2 FP32" \
+    litert convert HuggingFaceTB/SmolLM2-360M-Instruct --output "$MODEL_DIR"
 
-# --- 3. Benchmark SmolLM2 LLM Model ---
-run_case "Benchmark SmolLM2: Local benchmark of LLM generation" \
-    litert lm benchmark models/smollm2/model.litertlm -p 128 -d 128
+# --- 2. Convert with Weight-Only INT4 Quantization ---
+run_case "Convert: HuggingFace SmolLM2 INT4" \
+    litert convert HuggingFaceTB/SmolLM2-360M-Instruct --quantize-recipe weight_only_wi4_afp32 --output "$MODEL_INT4_DIR"
+
+# --- 3. Run SmolLM2 FP32 Model ---
+run_case "Run SmolLM2 FP32: Generative inference" \
+    litert lm run "$MODEL_PATH" --prompt="What is the capital of France?"
+
+# --- 4a. Run SmolLM2: Sampler configuration test ---
+run_case "Run SmolLM2: Sampler configuration" \
+    litert lm run "$MODEL_PATH" \
+        --prompt="What is the capital of France?" \
+        --max-num-tokens 1024 \
+        --top-k 40 \
+        --top-p 0.95 \
+        --temperature 0.7 \
+        --seed 42 \
+        --backend cpu
+
+# --- 4b. Run SmolLM2: Speculative decoding ---
+run_case "Run SmolLM2: Speculative decoding (Auto)" \
+    litert lm run "$MODEL_PATH" \
+        --prompt="What is the capital of France?" \
+        --enable-speculative-decoding auto \
+        --backend cpu
+
+# --- 5. Run SmolLM2 Raw Prompt ---
+run_case "Run SmolLM2 Raw: No template" \
+    litert lm run "$MODEL_PATH" \
+        --no-template \
+        --prompt="<|im_start|>user\nWhat is the capital of France?<|im_end|>\n<|im_start|>assistant\n"
+
+# --- 6. Import Model to Registry ---
+run_case "Import SmolLM2: Register model alias" \
+    litert-lm import "$MODEL_PATH" smollm2-alias
+
+# --- 7. List Models ---
+run_case "List Models: All imported LiteRT-LM models" \
+    litert-lm list
+
+# --- 8. Run SmolLM2 with System Preset ---
+run_case "Run SmolLM2 with Preset: System instruction" \
+    litert-lm run smollm2-alias --preset "$PRESET_PATH" --prompt="What is the capital of France?"
+
+# --- 9. Benchmark SmolLM2 FP32 ---
+run_case "Benchmark SmolLM2 FP32: Local generation" \
+    litert lm benchmark "$MODEL_PATH" -p 128 -d 128
+
+# --- 10. Benchmark SmolLM2 INT4 ---
+run_case "Benchmark SmolLM2 INT4: Local generation" \
+    litert lm benchmark "$MODEL_INT4_PATH" -p 128 -d 128
+
+# --- 11. Delete Model ---
+run_case "Delete Model: Remove registered alias" \
+    litert lm delete smollm2-alias
 
 # --- Summary Report ---
 print_summary_report "SmolLM2"


### PR DESCRIPTION
Expand SmolLM2 demo script with advanced run, quantization, and registry commands

- Adds dynamic weight-only INT4 quantization (`weight_only_wi4_afp32`) to SmolLM2 conversion.
- Integrates advanced `litert-lm run` parameters (sampler configurations, speculative decoding).
- Adds raw prompt inference (`--no-template`) with custom chat control tokens.
- Demonstrates local model registry management (`import`, `list`, `delete`).
- Integrates system instruction presets using a newly added `default.py` preset file.