### PR TITLE
Update litert_cli.ipynb

### DIFF
--- a/examples/litert_cli.ipynb
+++ b/examples/litert_cli.ipynb
@@ -78,7 +78,7 @@
     "!pip install -U torchao\n",
     "\n",
     "# Install litert-cli\n",
-    "!pip install litert-cli-nightly\n",
+    "!pip install litert-cli\n",
     "\n",
     "# 'litert compile' depends on Clang, and below make sure your Clang has version `18.x.x` or above\n",
     "!wget https://apt.llvm.org/llvm.sh\n",
@@ -206,7 +206,7 @@
     "!litert run resnet18/resnet18.tflite\n",
     "\n",
     "print(\"\\nRun ResNet18 on Desktop GPU============\\n\")\n",
-    "!litert run resnet18/resnet18_int8_dynamic.tflite --desktop --gpu --iterations 1 --print-tensors\n",
+    "!litert run resnet18/resnet18_int8_dynamic.tflite --desktop --cpu --gpu --iterations 1 --print-tensors\n",
     "\n",
     "print(\"\\nRun Inference for EfficientNet on Desktop GPU============\\n\")\n",
     "!litert run efficientnet/efficientnet_b1.tflite --gpu"


### PR DESCRIPTION
- Install litert-cli stable instead of nightly to avoid breakage
- Use flags "--cpu --gpu" to run resnet18 model