### PR TITLE
fix(qairt): update QAIRT SDK version to 2.47.0.260601 and fix static quantization test data shape

### DIFF
--- a/litert_cli/core/constants.py
+++ b/litert_cli/core/constants.py
@@ -74,7 +74,7 @@ LITERT_BINARIES_BASE_URL_ANDROID: str = (
 # Keep updating the version in sync with LiteRT releases, referencing
 # https://github.com/google-ai-edge/LiteRT/blob/main/third_party/qairt/workspace.bzl#L25
 _QAIRT_VERSION_MAP = {
-    "latest": "2.44.0.260225",  # Nightly / main branch
+    "latest": "2.47.0.260601",  # Nightly / main branch
     "2.1.4": "2.44.0.260225",  # Stable 2.1.4 release
     "2.1.5": "2.44.0.260225",  # Stable 2.1.5 release
     "2.1.6": "2.47.0.260601",  # Stable 2.1.6 release

--- a/litert_cli/test_data/dummy_calib_data.py
+++ b/litert_cli/test_data/dummy_calib_data.py
@@ -20,7 +20,7 @@ import numpy as np
 
 def get_calibration_data():
   dataset = [
-      {"args_0": np.random.rand(1, 224, 224, 3).astype(np.float32)}
+      {"args_0": np.random.rand(1, 3, 224, 224).astype(np.float32)}
       for _ in range(5)
   ]
   return {None: dataset}


### PR DESCRIPTION
## Summary
1. Update `_QAIRT_VERSION_MAP["latest"]`, `"2.1.6"` to `2.47.0.260601` in `constants.py` to match the QAIRT SDK version in LiteRT `main` branch (`third_party/qairt/workspace.bzl`).
2. Fix shape mismatch in `dummy_calib_data.py` from `(1, 224, 224, 3)` (NHWC) to `(1, 3, 224, 224)` (NCHW) to match `dummy_cv_model.tflite` input tensor shape, resolving the XNNPACK delegate reshape error in `quantize_test.sh`.